### PR TITLE
Backportet ordernumber check of max. 20 charecters from v2.

### DIFF
--- a/src/Vendr.Contrib.PaymentProviders.QuickPay/QuickPayCheckoutPaymentProvider.cs
+++ b/src/Vendr.Contrib.PaymentProviders.QuickPay/QuickPayCheckoutPaymentProvider.cs
@@ -14,6 +14,7 @@ using Vendr.Core;
 using Vendr.Core.Models;
 using Vendr.Core.Web.Api;
 using Vendr.Core.Web.PaymentProviders;
+using Vendr.Extensions;
 
 namespace Vendr.Contrib.PaymentProviders.QuickPay
 {
@@ -31,7 +32,8 @@ namespace Vendr.Contrib.PaymentProviders.QuickPay
 
         public override bool FinalizeAtContinueUrl => true;
 
-        public override IEnumerable<TransactionMetaDataDefinition> TransactionMetaDataDefinitions => new[]{
+        public override IEnumerable<TransactionMetaDataDefinition> TransactionMetaDataDefinitions => new[] {
+            new TransactionMetaDataDefinition("quickPayOrderId", "QuickPay Order ID"),
             new TransactionMetaDataDefinition("quickPayPaymentId", "QuickPay Payment ID"),
             new TransactionMetaDataDefinition("quickPayPaymentHash", "QuickPay Payment Hash")
         };
@@ -58,6 +60,7 @@ namespace Vendr.Contrib.PaymentProviders.QuickPay
             // Parse language - default language is English.
             Enum.TryParse(settings.Lang, true, out QuickPayLang lang);
 
+            var quickPayOrderId = order.Properties["quickPayOrderId"]?.Value;
             var quickPayPaymentId = order.Properties["quickPayPaymentId"]?.Value;
             var quickPayPaymentHash = order.Properties["quickPayPaymentHash"]?.Value ?? string.Empty;
             var quickPayPaymentLinkHash = order.Properties["quickPayPaymentLinkHash"]?.Value ?? string.Empty;
@@ -71,10 +74,53 @@ namespace Vendr.Contrib.PaymentProviders.QuickPay
                     var clientConfig = GetQuickPayClientConfig(settings);
                     var client = new QuickPayClient(clientConfig);
 
+                    var reference = order.OrderNumber;
+
+                    // QuickPay has a limit of order id between 4-20 characters.
+                    if (reference.Length > 20)
+                    {                       
+                        var store = Vendr.Services.StoreService.GetStore(order.StoreId);
+                        var orderNumberTemplate = store.OrderNumberTemplate;
+
+                        // If the ordernumber template is manipulatet, we then remove everything other than the VENDR automated ordernumber.
+                        if (orderNumberTemplate.Equals("{0}") == false)
+                        {
+                            var index = orderNumberTemplate.IndexOf("{0}");
+                            var prefix = orderNumberTemplate.Substring(0, index);
+                            var suffix = orderNumberTemplate.Substring(index + 3, orderNumberTemplate.Length - (index + 3));
+
+                            if (orderNumberTemplate.StartsWith("{0}"))
+                            {
+                                // Trim suffix
+                                reference = reference.Substring(index, reference.Length - suffix.Length);
+                            }
+                            else if (orderNumberTemplate.EndsWith("{0}"))
+                            {
+                                // Trim prefix
+                                reference = reference.Substring(prefix.Length - 1);
+                            }
+                            else if (orderNumberTemplate.Contains("{0}"))
+                            {
+                                // Trim prefix & suffix
+                                reference = reference.Substring(prefix.Length - 1, reference.Length - suffix.Length);
+                            }
+                        }
+                    }
+
+                    var metaData = new Dictionary<string, string>
+                    {
+                        { "orderReference", order.GenerateOrderReference() },
+                        { "orderId", order.Id.ToString("D") },
+                        { "orderNumber", order.OrderNumber }
+                    };
+
+                    quickPayOrderId = reference;
+
                     var payment = client.CreatePayment(new
                     {
-                        order_id = order.OrderNumber,
-                        currency = currencyCode
+                        order_id = quickPayOrderId,
+                        currency = currencyCode,
+                        Variables = metaData
                     });
 
                     quickPayPaymentId = GetTransactionId(payment);
@@ -111,6 +157,7 @@ namespace Vendr.Contrib.PaymentProviders.QuickPay
             {
                 MetaData = new Dictionary<string, string>
                 {
+                    { "quickPayOrderId", quickPayOrderId },
                     { "quickPayPaymentId", quickPayPaymentId },
                     { "quickPayPaymentHash", quickPayPaymentHash },
                     { "quickPayPaymentLinkHash", quickPayPaymentLinkHash }


### PR DESCRIPTION
Added a converted ordernumber check of max. 20 characters from v2.

Changed TrimEnd/TrimStart to Substrings, so we do not need any extentions.